### PR TITLE
add uri

### DIFF
--- a/Docs/uri.md
+++ b/Docs/uri.md
@@ -1,0 +1,23 @@
+# URI
+
+The `URI` type represents an URI.
+
+```swift
+public struct URI {
+    public var scheme: String?
+    public var userInfo: (username: String, password: String)?
+    public var host: String?
+    public var port: Int?
+    public var path: String?
+    public var query: [(key: String, value: String?)]
+    public var fragment: String?
+}
+```
+
+## Motivation
+
+Having `URI` as a `struct` allows it to conform to protocols in extensions.
+
+## References
+
+- [RFC 3986](https://tools.ietf.org/html/rfc3986)

--- a/Docs/uri.md
+++ b/Docs/uri.md
@@ -4,12 +4,22 @@ The `URI` type represents an URI.
 
 ```swift
 public struct URI {
+    public struct userInfo {
+        public var username: String
+        public var password: String
+    }
+
+    public struct Query {
+        public var key: String
+        public var value: String?
+    }
+
     public var scheme: String?
-    public var userInfo: (username: String, password: String)?
+    public var userInfo: userInfo?
     public var host: String?
     public var port: Int?
     public var path: String?
-    public var query: [(key: String, value: String?)]
+    public var query: [Query]
     public var fragment: String?
 }
 ```

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This is what we have so far:
 - [Byte](Docs/byte.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)
+- [URI](Docs/uri.md)
 
 Keep in mind that **everything** is open for discussion. We have [pull requests](https://github.com/swift-x/s4/pulls) for each item. Every discussion related to an item should be done in its respective PR, even if it's already merged/closed. We **urge** you to participate on the discussions and contribute.
 

--- a/Sources/URI.swift
+++ b/Sources/URI.swift
@@ -1,0 +1,9 @@
+public struct URI {
+    public var scheme: String?
+    public var userInfo: (username: String, password: String)?
+    public var host: String?
+    public var port: Int?
+    public var path: String?
+    public var query: [(key: String, value: String?)]
+    public var fragment: String?
+}

--- a/Sources/URI.swift
+++ b/Sources/URI.swift
@@ -1,9 +1,19 @@
 public struct URI {
+    public struct userInfo {
+        public var username: String
+        public var password: String
+    }
+
+    public struct Query {
+        public var key: String
+        public var value: String?
+    }
+
     public var scheme: String?
-    public var userInfo: (username: String, password: String)?
+    public var userInfo: userInfo?
     public var host: String?
     public var port: Int?
     public var path: String?
-    public var query: [(key: String, value: String?)]
+    public var query: [Query]
     public var fragment: String?
 }

--- a/Sources/URI.swift
+++ b/Sources/URI.swift
@@ -1,5 +1,5 @@
 public struct URI {
-    public struct userInfo {
+    public struct UserInfo {
         public var username: String
         public var password: String
     }
@@ -10,7 +10,7 @@ public struct URI {
     }
 
     public var scheme: String?
-    public var userInfo: userInfo?
+    public var userInfo: UserInfo?
     public var host: String?
     public var port: Int?
     public var path: String?


### PR DESCRIPTION
# URI

The `URI` type represents an URI.

```swift
public struct URI {
    public struct userInfo {
        public var username: String
        public var password: String
    }

    public struct Query {
        public var key: String
        public var value: String?
    }

    public var scheme: String?
    public var userInfo: userInfo?
    public var host: String?
    public var port: Int?
    public var path: String?
    public var query: [Query]
    public var fragment: String?
}
```

## Motivation

Having `URI` as a `struct` allows it to conform to protocols in extensions.

## References

- [RFC 3986](https://tools.ietf.org/html/rfc3986)