### PR TITLE
change http version to struct

### DIFF
--- a/Docs/http-version.md
+++ b/Docs/http-version.md
@@ -2,6 +2,7 @@
 
 The `HTTPVersion` type represents an HTTP version.
 
+```swift
 public struct HTTPVersion {
     public let major: Int
     public let minor: Int

--- a/Docs/http-version.md
+++ b/Docs/http-version.md
@@ -2,8 +2,10 @@
 
 The `HTTPVersion` type represents an HTTP version.
 
-```swift
-public typealias HTTPVersion = (major: Int, minor: Int)
+public struct HTTPVersion {
+    public let major: Int
+    public let minor: Int
+}
 ```
 
 ## Motivation

--- a/Sources/HTTPVersion.swift
+++ b/Sources/HTTPVersion.swift
@@ -1,1 +1,4 @@
-public typealias HTTPVersion = (major: Int, minor: Int)
+public struct HTTPVersion {
+    public let major: Int
+    public let minor: Int
+}


### PR DESCRIPTION
# HTTPVersion

The `HTTPVersion` type represents an HTTP version.

```swift
public struct HTTPVersion {
    public let major: Int
    public let minor: Int
}
```

## Motivation

HTTP version is needed to handle protocol differences properly.