### PR TITLE
add http header

### DIFF
--- a/Docs/http-header.md
+++ b/Docs/http-header.md
@@ -1,0 +1,14 @@
+# HTTPHeader
+
+The `HTTPHeader` type represents a single HTTP header.
+
+```swift
+public struct HTTPHeader {
+    public let name: String
+    public let value: String
+}
+```
+
+## Motivation
+
+Having `HTTPHeader` as a struct allows it to conform to protocols in extensions.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Swift X strives to maintain the following core beliefs for all of its standards:
 This is what we have so far:
 
 - [Byte](Docs/byte.md)
+- [HTTPHeader](Docs/http-header.md)
 - [HTTPMethod](Docs/http-method.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)

--- a/Sources/HTTPHeader.swift
+++ b/Sources/HTTPHeader.swift
@@ -1,0 +1,4 @@
+public struct HTTPHeader {
+    public let name: String
+    public let value: String
+}


### PR DESCRIPTION
# HTTPHeader

The `HTTPHeader` type represents a single HTTP header.

```swift
public struct HTTPHeader {
    public let name: String
    public let value: String
}
```

## Motivation

Having `HTTPHeader` as a struct allows it to conform to protocols in extensions.