### PR TITLE
add http headers

### DIFF
--- a/Docs/http-headers.md
+++ b/Docs/http-headers.md
@@ -1,0 +1,11 @@
+# HTTPHeaders
+
+The `HTTPHeaders` type represents HTTP headers.
+
+```swift
+public typealias HTTPHeaders = [HTTPHeader]
+```
+
+### Motivation
+
+Unfortunately the HTTP protocol allows duplicate headers (see Set-Cookie). So we have to make it an array instead of a dictionary.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Swift X strives to maintain the following core beliefs for all of its standards:
 This is what we have so far:
 
 - [Byte](Docs/byte.md)
+- [HTTPHeaders](Docs/http-headers.md)
 - [HTTPMethod](Docs/http-method.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)

--- a/Sources/HTTPHeaders.swift
+++ b/Sources/HTTPHeaders.swift
@@ -1,0 +1,1 @@
+public typealias HTTPHeaders = [HTTPHeader]


### PR DESCRIPTION
# HTTPHeaders

The `HTTPHeaders` type represents HTTP headers.

```swift
public typealias HTTPHeaders = [HTTPHeader]
```

### Motivation

Unfortunately the HTTP protocol allows duplicate headers (see Set-Cookie). So we have to make it an array instead of a dictionary.