### PR TITLE
add http body

### DIFF
--- a/Docs/http-body.md
+++ b/Docs/http-body.md
@@ -1,0 +1,14 @@
+# HTTPBody
+
+The `HTTPBody` type represents an HTTP body in buffer or stream form.
+
+```swift
+public enum HTTPBody {
+    case BufferBody(Data)
+    case StreamBody(Stream)
+}
+```
+
+### Motivation
+
+Buffer bodies are best suited for HTTP messages with Content-Length headers. Stream bodies are best suited for HTTP messages with Transfer-Encoding set to chunked.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Swift X strives to maintain the following core beliefs for all of its standards:
 This is what we have so far:
 
 - [Byte](Docs/byte.md)
+- [HTTPBody](Docs/http-body.md)
 - [HTTPMethod](Docs/http-method.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)

--- a/Sources/HTTPBody.swift
+++ b/Sources/HTTPBody.swift
@@ -1,0 +1,4 @@
+public enum HTTPBody {
+    case BufferBody(Data)
+    case StreamBody(Stream)
+}


### PR DESCRIPTION
# HTTPBody

The `HTTPBody` type represents an HTTP body in buffer or stream form.

```swift
public enum HTTPBody {
    case BufferBody(Data)
    case StreamBody(Stream)
}
```

### Motivation

Buffer bodies are best suited for HTTP messages with Content-Length headers. Stream bodies are best suited for HTTP messages with Transfer-Encoding set to chunked.