### PR TITLE
add storage

### DIFF
--- a/Docs/storage.md
+++ b/Docs/storage.md
@@ -1,0 +1,11 @@
+# Storage
+
+The `Storage` type represents arbitrary data that can be passed between middleware and a responder in a chain.
+
+```swift
+public typealias Storage = [String: Any]
+```
+
+## Motivation
+
+Having a storage in the HTTP messages makes middleware much more useful since they can pass forward parsed/serialized content, session information or just about any custom data.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is what we have so far:
 - [HTTPMethod](Docs/http-method.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)
+- [Storage](Docs/storage.md)
 
 Keep in mind that **everything** is open for discussion. We have [pull requests](https://github.com/swift-x/s4/pulls) for each item. Every discussion related to an item should be done in its respective PR, even if it's already merged/closed. We **urge** you to participate on the discussions and contribute.
 

--- a/Sources/Storage.swift
+++ b/Sources/Storage.swift
@@ -1,0 +1,1 @@
+public typealias Storage = [String: Any]


### PR DESCRIPTION
# Storage

The `Storage` type represents arbitrary data that can be passed between middleware and a responder in a chain.

```swift
public typealias Storage = [String: Any]
```

## Motivation

Having a storage in the HTTP messages makes middleware much more useful since they can pass forward parsed/serialized content, session information or just about any custom data.
