### PR TITLE
add custom data store

### DIFF
--- a/Docs/custom-data-store.md
+++ b/Docs/custom-data-store.md
@@ -1,0 +1,13 @@
+# CustomDataStore
+
+The `CustomDataStore` protocol represents a type that can hold custom data.
+
+```swift
+public protocol CustomDataStore {
+    var storage: Storage { get set }
+}
+```
+
+## Motivation
+
+Having a `Storage` property makes it possible to add optional stored properties on extensions.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Swift X strives to maintain the following core beliefs for all of its standards:
 This is what we have so far:
 
 - [Byte](Docs/byte.md)
+- [CustomDataStore](Docs/custom-data-store.md)
 - [HTTPMethod](Docs/http-method.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)

--- a/Sources/CustomDataStore.swift
+++ b/Sources/CustomDataStore.swift
@@ -1,0 +1,3 @@
+public protocol CustomDataStore {
+    var storage: Storage { get set }
+}


### PR DESCRIPTION
# CustomDataStore

The `CustomDataStore` protocol represents a type that can hold custom data.

```swift
public protocol CustomDataStore {
    var storage: Storage { get set }
}
```

## Motivation

Having a `Storage` property makes it possible to add optional stored properties on extensions.