### PR TITLE
add http-message

### DIFF
--- a/Docs/http-message.md
+++ b/Docs/http-message.md
@@ -1,0 +1,15 @@
+# HTTPMessage
+
+The `HTTPMessage` protocol represents properties common to HTTP messages (request/response).
+
+```swift
+public protocol HTTPMessage: CustomDataStore {
+    var version: HTTPVersion { get set }
+    var headers: HTTPHeaders { get set }
+    var body: HTTPBody { get set }
+}
+```
+
+## Motivation
+
+Having the `HTTPMessage` protocol makes adding computed properties common to requests and responses more convenient. It removes code duplication.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Swift X strives to maintain the following core beliefs for all of its standards:
 This is what we have so far:
 
 - [Byte](Docs/byte.md)
+- [HTTPMessage](Docs/http-message.md)
 - [HTTPMethod](Docs/http-method.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)

--- a/Sources/HTTPMessage.swift
+++ b/Sources/HTTPMessage.swift
@@ -1,0 +1,5 @@
+public protocol HTTPMessage: CustomDataStore {
+    var version: HTTPVersion { get set }
+    var headers: HTTPHeaders { get set }
+    var body: HTTPBody { get set }
+}


### PR DESCRIPTION
# HTTPMessage

The `HTTPMessage` protocol represents properties common to HTTP messages (request/response).

```swift
public protocol HTTPMessage: CustomDataStore {
    var version: HTTPVersion { get set }
    var headers: HTTPHeaders { get set }
    var body: HTTPBody { get set }
}
```

## Motivation

Having the `HTTPMessage` protocol makes adding computed properties common to requests and responses more convenient. It removes code duplication.