### PR TITLE
add http request

### DIFF
--- a/Docs/http-request.md
+++ b/Docs/http-request.md
@@ -1,0 +1,18 @@
+# HTTPRequest
+
+The `HTTPRequest` type represents an HTTP request.
+
+```swift
+public struct HTTPRequest: HTTPMessage {
+    public var method: HTTPMethod
+    public var uri: URI
+    public var version: HTTPVersion
+    public var headers: HTTPHeaders
+    public var body: HTTPBody
+    public var storage: Storage = [:]
+}
+```
+
+## Motivation
+
+Having `HTTPRequest` as a `struct` allows it to conform to protocols in extensions.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is what we have so far:
 
 - [Byte](Docs/byte.md)
 - [HTTPMethod](Docs/http-method.md)
+- [HTTPRequest](Docs/http-request.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)
 

--- a/Sources/HTTPRequest.swift
+++ b/Sources/HTTPRequest.swift
@@ -1,0 +1,8 @@
+public struct HTTPRequest: HTTPMessage {
+    public var method: HTTPMethod
+    public var uri: URI
+    public var version: HTTPVersion
+    public var headers: HTTPHeaders
+    public var body: HTTPBody
+    public var storage: Storage
+}


### PR DESCRIPTION
# HTTPRequest

The `HTTPRequest` type represents an HTTP request.

```swift
public struct HTTPRequest: HTTPMessage {
    public var method: HTTPMethod
    public var uri: URI
    public var version: HTTPVersion
    public var headers: HTTPHeaders
    public var body: HTTPBody
    public var storage: Storage = [:]
}
```

## Motivation

Having `HTTPRequest` as a `struct` allows it to conform to protocols in extensions.