### PR TITLE
add http response

### DIFF
--- a/Docs/http-response.md
+++ b/Docs/http-response.md
@@ -1,0 +1,17 @@
+## HTTPResponse
+
+The `HTTPResponse` type represents an HTTP response.
+
+```swift
+public struct HTTPResponse: HTTPMessage {
+    public var version: HTTPVersion
+    public var status: HTTPStatus
+    public var headers: HTTPHeaders
+    public var body: HTTPBody
+    public var storage: Storage = [:]
+}
+```
+
+### Motivation
+
+Having `HTTPResponse` as a `struct` allows it to conform to protocols in extensions.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is what we have so far:
 
 - [Byte](Docs/byte.md)
 - [HTTPMethod](Docs/http-method.md)
+- [HTTPResponse](Docs/http-response.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)
 

--- a/Sources/HTTPResponse.swift
+++ b/Sources/HTTPResponse.swift
@@ -1,0 +1,7 @@
+public struct HTTPResponse: HTTPMessage {
+    public var version: HTTPVersion
+    public var status: HTTPStatus
+    public var headers: HTTPHeaders
+    public var body: HTTPBody
+    public var storage: Storage
+}


### PR DESCRIPTION
## HTTPResponse

The `HTTPResponse` type represents an HTTP response.

```swift
public struct HTTPResponse: HTTPMessage {
    public var version: HTTPVersion
    public var status: HTTPStatus
    public var headers: HTTPHeaders
    public var body: HTTPBody
    public var storage: Storage = [:]
}
```

### Motivation

Having `HTTPResponse` as a `struct` allows it to conform to protocols in extensions.