### PR TITLE
add http responder

### DIFF
--- a/Docs/http-responder.md
+++ b/Docs/http-responder.md
@@ -1,0 +1,13 @@
+# HTTPResponder
+
+The `HTTPResponder` protocol represents a type that can respond to HTTP requests.
+
+```swift
+public protocol HTTPResponder {
+    func respond(request: HTTPRequest) throws -> HTTPResponse
+}
+```
+
+## Motivation
+
+This is the most important protocol in an HTTP context. The responder is the base for higher-level abstractions like routers and middlewares.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is what we have so far:
 
 - [Byte](Docs/byte.md)
 - [HTTPMethod](Docs/http-method.md)
+- [HTTPResponder](Docs/http-responder.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)
 

--- a/Sources/HTTPResponder.swift
+++ b/Sources/HTTPResponder.swift
@@ -1,0 +1,3 @@
+public protocol HTTPResponder {
+    func respond(request: HTTPRequest) throws -> HTTPResponse
+}


### PR DESCRIPTION
# HTTPResponder

The `HTTPResponder` protocol represents a type that can respond to HTTP requests.

```swift
public protocol HTTPResponder {
    func respond(request: HTTPRequest) throws -> HTTPResponse
}
```

## Motivation

This is the most important protocol in an HTTP context. The responder is the base for higher-level abstractions like routers and middlewares.