### PR TITLE
add middleware

### DIFF
--- a/Docs/http-middleware.md
+++ b/Docs/http-middleware.md
@@ -1,0 +1,14 @@
+# HTTPMiddleware
+
+The `HTTPMiddleware` protocol represents a type that responds to an HTTP request optionally forwarding the request to the chain.
+
+
+```swift
+public protocol HTTPMiddleware {
+    func respond(request: HTTPRequest, chain: HTTPResponder) throws -> HTTPResponse
+}
+```
+
+## Motivation
+
+Middleware drastically reduces boilerplate and allows code reuse. This degisn allows middleware to be applied on the server and on the client, reducing boilerplate even further.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This is what we have so far:
 
 - [Byte](Docs/byte.md)
 - [HTTPMethod](Docs/http-method.md)
+- [HTTPMiddleware](Docs/http-middleware.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)
 

--- a/Sources/HTTPMiddleware.swift
+++ b/Sources/HTTPMiddleware.swift
@@ -1,0 +1,3 @@
+public protocol HTTPMiddleware {
+    func respond(request: HTTPRequest, chain: HTTPResponder) throws -> HTTPResponse
+}


### PR DESCRIPTION
# HTTPMiddleware

The `HTTPMiddleware` protocol represents a type that responds to an HTTP request optionally forwarding the request to the chain.


```swift
public protocol HTTPMiddleware {
    func respond(request: HTTPRequest, chain: HTTPResponder) throws -> HTTPResponse
}
```

## Motivation

Middleware drastically reduces boilerplate and allows code reuse. This degisn allows middleware to be applied on the server and on the client, reducing boilerplate even further.