### PR TITLE
add stream

### DIFF
--- a/Docs/stream.md
+++ b/Docs/stream.md
@@ -1,0 +1,30 @@
+# Stream
+
+The `Stream` protocol represents a bi-directional stream of binary data.
+
+```swift
+public protocol Stream {
+    var closed: Bool { get }
+    func close() -> Bool
+    func receive() throws -> Data
+    func send(data: Data) throws
+    func flush() throws
+}
+```
+
+## Motivation
+
+With an abstraction for a stream we can avoid tight coupling and get the advantage of composition. One could, for example, wrap a raw `TCP` stream in an `SSL` stream that encrypts/decrypts the binary data coming from the raw stream.
+
+```swift
+public final class SSLStream: Stream {
+    private let context: SSLContext
+    private let rawStream: Stream
+
+    public init(context: SSLContext, rawStream: Stream) throws {
+        ...
+    }
+}
+```
+
+The API consuming the stream doesn't need to know how the binary data is created. It only needs the binary data.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This is what we have so far:
 - [HTTPMethod](Docs/http-method.md)
 - [HTTPStatus](Docs/http-status.md)
 - [HTTPVersion](Docs/http-version.md)
+- [Stream](Docs/stream.md)
 
 Keep in mind that **everything** is open for discussion. We have [pull requests](https://github.com/swift-x/s4/pulls) for each item. Every discussion related to an item should be done in its respective PR, even if it's already merged/closed. We **urge** you to participate on the discussions and contribute.
 

--- a/Sources/Stream.swift
+++ b/Sources/Stream.swift
@@ -1,0 +1,7 @@
+public protocol Stream {
+    var closed: Bool { get }
+    func close() -> Bool
+    func receive() throws -> Data
+    func send(data: Data) throws
+    func flush() throws
+}


### PR DESCRIPTION
# Stream

The `Stream` protocol represents a bi-directional stream of binary data.

```swift
public protocol Stream {
    var closed: Bool { get }
    func close() -> Bool
    func receive() throws -> Data
    func send(data: Data) throws
    func flush() throws
}
```

## Motivation

With an abstraction for a stream we can avoid tight coupling and get the advantage of composition. One could, for example, wrap a raw `TCP` stream in an `SSL` stream that encrypts/decrypts the binary data coming from the raw stream.

```swift
public final class SSLStream: Stream {
    private let context: SSLContext
    private let rawStream: Stream

    public init(context: SSLContext, rawStream: Stream) throws {
        ...
    }
}
```

The API consuming the stream doesn't need to know how the binary data is created. It only needs the binary data.