### PR TITLE
add request/response convertibles

### DIFF
--- a/Docs/http-request-convertible.md
+++ b/Docs/http-request-convertible.md
@@ -1,0 +1,11 @@
+# HTTPRequestConvertible
+
+The `HTTPRequestConvertible` protocol represents a type that can be converted to and from an S4 HTTP request.
+
+```swift
+public protocol HTTPRequestConvertible: HTTPRequestInitializable, HTTPRequestRepresentable {}
+```
+
+## Motivation
+
+If you don't want to use S4's native request you can convert it to and from your own request using this protocol.

--- a/Docs/http-request-initializable.md
+++ b/Docs/http-request-initializable.md
@@ -1,0 +1,13 @@
+# HTTPRequestInitializable
+
+The `HTTPRequestInitializable` protocol represents a type that can be initialized from an S4 HTTP request.
+
+```swift
+public protocol HTTPRequestInitializable {
+    init(S4Request: HTTPRequest)
+}
+```
+
+## Motivation
+
+If you don't want to use S4's native request you can convert it to your own request using this protocol.

--- a/Docs/http-request-representable.md
+++ b/Docs/http-request-representable.md
@@ -1,0 +1,13 @@
+# HTTPRequestRepresentable
+
+The `HTTPRequestRepresentable` protocol represents a type that can be converted to an S4 HTTP request.
+
+```swift
+public protocol HTTPRequestRepresentable {
+    var S4Request: HTTPRequest { get }
+}
+```
+
+## Motivation
+
+If you don't want to use S4's native request you can convert it from your own request using this protocol.

--- a/Docs/http-response-convertible.md
+++ b/Docs/http-response-convertible.md
@@ -1,0 +1,11 @@
+# HTTPResponseConvertible
+
+The `HTTPResponseConvertible` protocol represents a type that can be converted to and from an S4 HTTP response.
+
+```swift
+public protocol HTTPResponseConvertible: HTTPResponseInitializable, HTTPResponseRepresentable {}
+```
+
+## Motivation
+
+If you don't want to use S4's native response you can convert it to and from your own response using this protocol.

--- a/Docs/http-response-initializable.md
+++ b/Docs/http-response-initializable.md
@@ -1,0 +1,13 @@
+# HTTPResponseInitializable
+
+The `HTTPResponseInitializable` protocol represents a type that can be initialized from an S4 HTTP response.
+
+```swift
+public protocol HTTPResponseInitializable {
+    init(S4Response: HTTPResponse)
+}
+```
+
+## Motivation
+
+If you don't want to use S4's native response you can convert it to your own response using this protocol.

--- a/Docs/http-response-representable.md
+++ b/Docs/http-response-representable.md
@@ -1,0 +1,13 @@
+# HTTPResponseRepresentable
+
+The `HTTPResponseRepresentable` protocol represents a type that can be converted to an S4 HTTP response.
+
+```swift
+public protocol HTTPResponseRepresentable {
+    var S4Response: HTTPResponse { get }
+}
+```
+
+## Motivation
+
+If you don't want to use S4's native response you can convert it from your own response using this protocol.

--- a/Sources/HTTPRequestConvertible.swift
+++ b/Sources/HTTPRequestConvertible.swift
@@ -1,0 +1,1 @@
+public protocol HTTPRequestConvertible: HTTPRequestInitializable, HTTPRequestRepresentable {}

--- a/Sources/HTTPRequestInitializable.swift
+++ b/Sources/HTTPRequestInitializable.swift
@@ -1,0 +1,3 @@
+public protocol HTTPRequestInitializable {
+    init(S4Request: HTTPRequest)
+}

--- a/Sources/HTTPRequestRepresentable.swift
+++ b/Sources/HTTPRequestRepresentable.swift
@@ -1,0 +1,3 @@
+public protocol HTTPRequestRepresentable {
+    var S4Request: HTTPRequest { get }
+}

--- a/Sources/HTTPResponseConvertible.swift
+++ b/Sources/HTTPResponseConvertible.swift
@@ -1,0 +1,1 @@
+public protocol HTTPResponseConvertible: HTTPResponseInitializable, HTTPResponseRepresentable {}

--- a/Sources/HTTPResponseInitializable.swift
+++ b/Sources/HTTPResponseInitializable.swift
@@ -1,0 +1,3 @@
+public protocol HTTPResponseInitializable {
+    init(S4Response: HTTPResponse)
+}

--- a/Sources/HTTPResponseRepresentable.swift
+++ b/Sources/HTTPResponseRepresentable.swift
@@ -1,0 +1,3 @@
+public protocol HTTPResponseRepresentable {
+    var S4Response: HTTPResponse { get }
+}


### PR DESCRIPTION
# HTTPRequestInitializable

The `HTTPRequestInitializable` protocol represents a type that can be initialized from an S4 HTTP request.

```swift
public protocol HTTPRequestInitializable {
    init(S4Request: HTTPRequest)
}
```

## Motivation

If you don't want to use S4's native request you can convert it to your own request using this protocol.

# HTTPRequestRepresentable

The `HTTPRequestRepresentable` protocol represents a type that can be converted to an S4 HTTP request.

```swift
public protocol HTTPRequestRepresentable {
    var S4Request: HTTPRequest { get }
}
```

## Motivation

If you don't want to use S4's native request you can convert it from your own request using this protocol.

# HTTPRequestConvertible

The `HTTPRequestConvertible` protocol represents a type that can be converted to and from an S4 HTTP request.

```swift
public protocol HTTPRequestConvertible: HTTPRequestInitializable, HTTPRequestRepresentable {}
```

## Motivation

If you don't want to use S4's native request you can convert it to and from your own request using this protocol.

# HTTPResponseInitializable

The `HTTPResponseInitializable` protocol represents a type that can be initialized from an S4 HTTP response.

```swift
public protocol HTTPResponseInitializable {
    init(S4Response: HTTPResponse)
}
```

## Motivation

If you don't want to use S4's native response you can convert it to your own response using this protocol.

# HTTPResponseRepresentable

The `HTTPResponseRepresentable` protocol represents a type that can be converted to an S4 HTTP response.

```swift
public protocol HTTPResponseRepresentable {
    var S4Response: HTTPResponse { get }
}
```

## Motivation

If you don't want to use S4's native response you can convert it from your own response using this protocol.

# HTTPResponseConvertible

The `HTTPResponseConvertible` protocol represents a type that can be converted to and from an S4 HTTP response.

```swift
public protocol HTTPResponseConvertible: HTTPResponseInitializable, HTTPResponseRepresentable {}
```

## Motivation

If you don't want to use S4's native response you can convert it to and from your own response using this protocol.