### PR TITLE
Add Client

### DIFF
--- a/Sources/Client.swift
+++ b/Sources/Client.swift
@@ -1,0 +1,3 @@
+public protocol Client: Responder {
+    init(uri: URI) throws
+}


### PR DESCRIPTION
At its core, a client:
- takes an HTTP request
- sends it (through a socket) to a location
- returns the HTTP response
- throws any errors it came upon along the way

Ideally, `protocol Client: Responder {}` would be enough since the `Request` already stores the URI. However, in most cases, that consists of `path` + `query` + `fragment` and is relative, rather than containing the absolute url. Therefore, adding a `URI` property (or in this case, an initializer) seems to be necessary. This also lets the client be more powerful since it can persist the URI and take in multiple requests with a base path, and execute them all to the same host (allowing the requests to be more encapsulated).