### PR TITLE
Update travis to delete dependency tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ osx_image: xcode7.3
 install:
   - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/02090c7ede5a637b76e6df1710e83cd0bbe7dcdf/swiftenv-install.sh)"
 script:
+  - swift build --fetch # clones all dependencies
+  - rm -rf Packages/*/Tests # deletes dependency's tests until duplicate Package.tests issue can be resolved in SPM. At that point, remove.
   - swift build
   - swift build --configuration release
   - swift test


### PR DESCRIPTION
There's a temporary issue in SPM where dependency's tests cause the Package's tests to fail.