### PR TITLE
Method comparison by description

### DIFF
--- a/Sources/Method.swift
+++ b/Sources/Method.swift
@@ -93,5 +93,5 @@ extension Method: Hashable {
 }
 
 public func ==(lhs: Method, rhs: Method) -> Bool {
-    return lhs.hashValue == rhs.hashValue
+    return lhs.description == rhs.description
 }


### PR DESCRIPTION
**Rationale**: if one create a `Method.other(method: "GET")`, it will not be equal to `.get`, and I suppose it should be. `==` are all about comparing values, and does it matter how that value is described?